### PR TITLE
[CONJ-769] Add a hint about createDatabaseIfNotExist

### DIFF
--- a/documentation/failover-and-high-availability-with-mariadb-connector-j.creole
+++ b/documentation/failover-and-high-availability-with-mariadb-connector-j.creole
@@ -241,6 +241,7 @@ Example of connection string
 }}}
 
 Another difference is the option "socketTimeout" that defaults to 10 seconds, meaning that - if not changed - queries exceeding 10 seconds will throw exceptions.  
+Note that the option "createDatabaseIfNotExist=true" causes reader instances to be blacklisted during the creation of a new connection, because this option sends a "CREATE DATABASE" statement to the reader which is not read-only and therefore is rejected.
 
 ==Aurora connection loop
 


### PR DESCRIPTION
I reported a bug because the `createDatabaseIfNotExist` setting causes reader instances to be silently blacklisted. You can find the bug report at [CONJ-769](https://jira.mariadb.org/browse/CONJ-769).
This commit adds a sentence about this argument to the section about Aurora specific configuration options.