### PR TITLE
Use java charset caching mechanisms for strings

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbClob.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbClob.java
@@ -59,6 +59,7 @@ import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.SQLException;
 import org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializable {
 
@@ -95,7 +96,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
    * @return string value of blob content.
    */
   public String toString() {
-    return new String(data, offset, length, StandardCharsets.UTF_8);
+    return StringUtils.newString(data, offset, length, StandardCharsets.UTF_8);
   }
 
   /**
@@ -211,7 +212,7 @@ public class MariaDbClob extends MariaDbBlob implements Clob, NClob, Serializabl
    */
   public int setString(long pos, String str) throws SQLException {
     int bytePosition = utf8Position((int) pos - 1);
-    super.setBytes(bytePosition + 1 - offset, str.getBytes(StandardCharsets.UTF_8));
+    super.setBytes(bytePosition + 1 - offset, StringUtils.getBytes(str, StandardCharsets.UTF_8));
     return str.length();
   }
 

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/Buffer.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/Buffer.java
@@ -55,6 +55,7 @@ package org.mariadb.jdbc.internal.com.read;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class Buffer {
 
@@ -93,7 +94,7 @@ public class Buffer {
     while (remaining() > 0 && (buf[position++] != 0)) {
       cnt++;
     }
-    return new String(buf, initialPosition, cnt, charset);
+    return StringUtils.newString(buf, initialPosition, cnt, charset);
   }
 
   /**
@@ -120,7 +121,7 @@ public class Buffer {
    */
   public String readStringLengthEncoded(final Charset charset) {
     int length = (int) getLengthEncodedNumeric();
-    String string = new String(buf, position, length, charset);
+    String string = StringUtils.newString(buf, position, length, charset);
     position += length;
     return string;
   }
@@ -359,7 +360,7 @@ public class Buffer {
    * @param value value to write
    */
   public void writeStringLength(String value) {
-    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    byte[] bytes = StringUtils.getBytes(value, StandardCharsets.UTF_8);
     int length = bytes.length;
     while (remaining() < length + 9) {
       grow();

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/ErrorPacket.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/ErrorPacket.java
@@ -53,6 +53,7 @@
 package org.mariadb.jdbc.internal.com.read;
 
 import java.nio.charset.StandardCharsets;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 /** See protocol documentation https://mariadb.com/kb/en/err_packet/ */
 public class ErrorPacket {
@@ -76,7 +77,7 @@ public class ErrorPacket {
     } else {
       // Pre-4.1 message, still can be output in newer versions (e.g with 'Too many connections')
       message =
-          new String(
+          StringUtils.newString(
               buffer.buf, buffer.position, buffer.limit - buffer.position, StandardCharsets.UTF_8);
       sqlState = "HY000";
     }

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/ColumnDefinition.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/ColumnDefinition.java
@@ -57,6 +57,7 @@ import java.sql.Types;
 import org.mariadb.jdbc.internal.ColumnType;
 import org.mariadb.jdbc.internal.com.read.Buffer;
 import org.mariadb.jdbc.internal.util.constant.ColumnFlags;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 /** Protocol details : https://mariadb.com/kb/en/resultset/#column-definition-packet */
 public class ColumnDefinition {
@@ -163,7 +164,7 @@ public class ColumnDefinition {
    * @return ColumnInformation
    */
   public static ColumnDefinition create(String name, ColumnType type) {
-    byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+    byte[] nameBytes = StringUtils.getBytes(name, StandardCharsets.UTF_8);
 
     byte[] arr = new byte[19 + 2 * nameBytes.length];
     int pos = 0;

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java
@@ -54,6 +54,7 @@ import org.mariadb.jdbc.internal.io.input.PacketInputStream;
 import org.mariadb.jdbc.internal.io.input.StandardPacketInputStream;
 import org.mariadb.jdbc.internal.protocol.Protocol;
 import org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 import org.mariadb.jdbc.util.Options;
 
 @SuppressWarnings({
@@ -936,7 +937,7 @@ public class SelectResultSet implements ResultSet {
       return null;
     }
     return new ByteArrayInputStream(
-        new String(row.buf, row.pos, row.getLengthMaxFieldSize(), StandardCharsets.UTF_8)
+        StringUtils.newString(row.buf, row.pos, row.getLengthMaxFieldSize(), StandardCharsets.UTF_8)
             .getBytes());
   }
 
@@ -1137,7 +1138,7 @@ public class SelectResultSet implements ResultSet {
       return null;
     }
     return new ByteArrayInputStream(
-        new String(row.buf, row.pos, row.getLengthMaxFieldSize(), StandardCharsets.UTF_8)
+        StringUtils.newString(row.buf, row.pos, row.getLengthMaxFieldSize(), StandardCharsets.UTF_8)
             .getBytes());
   }
 

--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/BinaryRowProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/BinaryRowProtocol.java
@@ -63,6 +63,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import org.mariadb.jdbc.internal.com.read.resultset.ColumnDefinition;
 import org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 import org.mariadb.jdbc.util.Options;
 
 public class BinaryRowProtocol extends RowProtocol {
@@ -294,11 +295,11 @@ public class BinaryRowProtocol extends RowProtocol {
     switch (columnInfo.getColumnType()) {
       case STRING:
         if (getMaxFieldSize() > 0) {
-          return new String(
+          return StringUtils.newString(
                   buf, pos, Math.min(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
               .substring(0, Math.min(getMaxFieldSize(), length));
         }
-        return new String(buf, pos, length, StandardCharsets.UTF_8);
+        return StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
 
       case BIT:
         return String.valueOf(parseBit());
@@ -349,11 +350,11 @@ public class BinaryRowProtocol extends RowProtocol {
         return null;
       default:
         if (getMaxFieldSize() > 0) {
-          return new String(
+          return StringUtils.newString(
                   buf, pos, Math.min(getMaxFieldSize() * 3, length), StandardCharsets.UTF_8)
               .substring(0, Math.min(getMaxFieldSize(), length));
         }
-        return new String(buf, pos, length, StandardCharsets.UTF_8);
+        return StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
     }
   }
 
@@ -411,7 +412,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case VARSTRING:
       case VARCHAR:
       case STRING:
-        value = Long.parseLong(new String(buf, pos, length, StandardCharsets.UTF_8));
+        value = Long.parseLong(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
         break;
       default:
         throw new SQLException(
@@ -521,7 +522,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case VARSTRING:
       case VARCHAR:
       case STRING:
-        return Long.parseLong(new String(buf, pos, length, StandardCharsets.UTF_8));
+        return Long.parseLong(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
       default:
         throw new SQLException(
             "getLong not available for data field type "
@@ -600,7 +601,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case STRING:
       case OLDDECIMAL:
         try {
-          return Float.valueOf(new String(buf, pos, length, StandardCharsets.UTF_8));
+          return Float.valueOf(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
         } catch (NumberFormatException nfe) {
           SQLException sqlException =
               new SQLException(
@@ -698,7 +699,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case STRING:
       case OLDDECIMAL:
         try {
-          return Double.valueOf(new String(buf, pos, length, StandardCharsets.UTF_8));
+          return Double.valueOf(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
         } catch (NumberFormatException nfe) {
           SQLException sqlException =
               new SQLException(
@@ -779,7 +780,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case VARCHAR:
       case STRING:
       case OLDDECIMAL:
-        return new BigDecimal(new String(buf, pos, length, StandardCharsets.UTF_8));
+        return new BigDecimal(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
       default:
         throw new SQLException(
             "getBigDecimal not available for data field type "
@@ -810,7 +811,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case TIME:
         throw new SQLException("Cannot read Date using a Types.TIME field");
       case STRING:
-        String rawValue = new String(buf, pos, length, StandardCharsets.UTF_8);
+        String rawValue = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         if ("0000-00-00".equals(rawValue)) {
           lastValueNull |= BIT_LAST_ZERO_DATE;
           return null;
@@ -989,7 +990,7 @@ public class BinaryRowProtocol extends RowProtocol {
 
       case STRING:
       case VARSTRING:
-        String rawValue = new String(buf, pos, length, StandardCharsets.UTF_8);
+        String rawValue = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         if (rawValue.startsWith("0000-00-00 00:00:00")) {
           lastValueNull |= BIT_LAST_ZERO_DATE;
           return null;
@@ -1178,7 +1179,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case OLDDECIMAL:
         return getInternalBigDecimal(columnInfo).longValue() != 0;
       default:
-        final String rawVal = new String(buf, pos, length, StandardCharsets.UTF_8);
+        final String rawVal = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         return !("false".equals(rawVal) || "0".equals(rawVal));
     }
   }
@@ -1227,7 +1228,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case VARSTRING:
       case VARCHAR:
       case STRING:
-        value = Long.parseLong(new String(buf, pos, length, StandardCharsets.UTF_8));
+        value = Long.parseLong(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
         break;
       default:
         throw new SQLException(
@@ -1287,7 +1288,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case VARSTRING:
       case VARCHAR:
       case STRING:
-        value = Long.parseLong(new String(buf, pos, length, StandardCharsets.UTF_8));
+        value = Long.parseLong(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
         break;
       default:
         throw new SQLException(
@@ -1321,7 +1322,7 @@ public class BinaryRowProtocol extends RowProtocol {
         return value.toString();
       }
     }
-    String rawValue = new String(buf, pos, length, StandardCharsets.UTF_8);
+    String rawValue = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
     if ("0000-00-00".equals(rawValue)) {
       return null;
     }
@@ -1441,7 +1442,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case OLDDECIMAL:
         return BigInteger.valueOf(getInternalBigDecimal(columnInfo).longValue());
       default:
-        return new BigInteger(new String(buf, pos, length, StandardCharsets.UTF_8));
+        return new BigInteger(StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8));
     }
   }
 
@@ -1496,7 +1497,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case Types.CHAR:
 
         // string conversion
-        String raw = new String(buf, pos, length, StandardCharsets.UTF_8);
+        String raw = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         if (raw.startsWith("0000-00-00 00:00:00")) {
           return null;
         }
@@ -1607,7 +1608,7 @@ public class BinaryRowProtocol extends RowProtocol {
         case Types.VARCHAR:
         case Types.LONGVARCHAR:
         case Types.CHAR:
-          String raw = new String(buf, pos, length, StandardCharsets.UTF_8);
+          String raw = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
           try {
             return OffsetTime.parse(raw, DateTimeFormatter.ISO_OFFSET_TIME);
           } catch (DateTimeParseException dateParserEx) {
@@ -1700,7 +1701,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case Types.LONGVARCHAR:
       case Types.CHAR:
         // string conversion
-        String raw = new String(buf, pos, length, StandardCharsets.UTF_8);
+        String raw = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         try {
           return LocalTime.parse(
               raw, DateTimeFormatter.ISO_LOCAL_TIME.withZone(timeZone.toZoneId()));
@@ -1763,7 +1764,7 @@ public class BinaryRowProtocol extends RowProtocol {
       case Types.LONGVARCHAR:
       case Types.CHAR:
         // string conversion
-        String raw = new String(buf, pos, length, StandardCharsets.UTF_8);
+        String raw = StringUtils.newString(buf, pos, length, StandardCharsets.UTF_8);
         if (raw.startsWith("0000-00-00")) {
           return null;
         }

--- a/src/main/java/org/mariadb/jdbc/internal/com/send/ComQuery.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/send/ComQuery.java
@@ -59,6 +59,7 @@ import org.mariadb.jdbc.internal.com.Packet;
 import org.mariadb.jdbc.internal.com.send.parameters.ParameterHolder;
 import org.mariadb.jdbc.internal.io.output.PacketOutputStream;
 import org.mariadb.jdbc.internal.util.dao.ClientPrepareResult;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class ComQuery {
 
@@ -275,13 +276,13 @@ public class ComQuery {
     writer.startPacket(0);
     writer.write(Packet.COM_QUERY);
     // index is already set to 1 for first one
-    writer.write(firstQuery.getBytes(StandardCharsets.UTF_8));
+    writer.write(StringUtils.getBytes(firstQuery, StandardCharsets.UTF_8));
 
     int index = currentIndex;
 
     // add query with ";"
     while (index < queries.size()) {
-      byte[] sqlByte = queries.get(index).getBytes(StandardCharsets.UTF_8);
+      byte[] sqlByte = StringUtils.getBytes(queries.get(index), StandardCharsets.UTF_8);
       if (!writer.checkRemainingSize(sqlByte.length + 1)) {
         break;
       }

--- a/src/main/java/org/mariadb/jdbc/internal/com/send/SendChangeDbPacket.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/send/SendChangeDbPacket.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.mariadb.jdbc.internal.com.Packet;
 import org.mariadb.jdbc.internal.io.output.PacketOutputStream;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class SendChangeDbPacket {
 
@@ -69,7 +70,7 @@ public class SendChangeDbPacket {
   public static void send(final PacketOutputStream pos, final String database) throws IOException {
     pos.startPacket(0);
     pos.write(Packet.COM_INIT_DB);
-    pos.write(database.getBytes(StandardCharsets.UTF_8));
+    pos.write(StringUtils.getBytes(database, StandardCharsets.UTF_8));
     pos.flush();
   }
 }

--- a/src/main/java/org/mariadb/jdbc/internal/com/send/parameters/StringParameter.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/send/parameters/StringParameter.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.mariadb.jdbc.internal.ColumnType;
 import org.mariadb.jdbc.internal.io.output.PacketOutputStream;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class StringParameter implements Cloneable, ParameterHolder {
 
@@ -87,7 +88,7 @@ public class StringParameter implements Cloneable, ParameterHolder {
    * @throws IOException if socket error occur
    */
   public void writeBinary(final PacketOutputStream pos) throws IOException {
-    byte[] bytes = stringValue.getBytes(StandardCharsets.UTF_8);
+    byte[] bytes = StringUtils.getBytes(stringValue, StandardCharsets.UTF_8);
     pos.writeFieldLength(bytes.length);
     pos.write(bytes);
   }

--- a/src/main/java/org/mariadb/jdbc/internal/io/output/AbstractPacketOutputStream.java
+++ b/src/main/java/org/mariadb/jdbc/internal/io/output/AbstractPacketOutputStream.java
@@ -57,6 +57,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.mariadb.jdbc.internal.io.LruTraceCache;
 import org.mariadb.jdbc.internal.util.exceptions.MaxAllowedPacketException;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public abstract class AbstractPacketOutputStream extends FilterOutputStream
     implements PacketOutputStream {
@@ -498,7 +499,7 @@ public abstract class AbstractPacketOutputStream extends FilterOutputStream
 
     // not enough space remaining
     if (charsLength * 3 + 2 >= buf.length - pos) {
-      byte[] arr = str.getBytes(StandardCharsets.UTF_8);
+      byte[] arr = StringUtils.getBytes(str, StandardCharsets.UTF_8);
       if (escape) {
         write(QUOTE);
         writeBytesEscaped(arr, arr.length, noBackslashEscapes);
@@ -666,7 +667,7 @@ public abstract class AbstractPacketOutputStream extends FilterOutputStream
     char[] buffer = new char[4096];
     int len;
     while ((len = reader.read(buffer)) >= 0) {
-      byte[] data = new String(buffer, 0, len).getBytes(StandardCharsets.UTF_8);
+      byte[] data = StringUtils.getBytes(new String(buffer, 0, len), StandardCharsets.UTF_8);
       if (escape) {
         writeBytesEscaped(data, data.length, noBackslashEscapes);
       } else {
@@ -689,7 +690,7 @@ public abstract class AbstractPacketOutputStream extends FilterOutputStream
     char[] buffer = new char[4096];
     int len;
     while (length > 0 && (len = reader.read(buffer, 0, Math.min((int) length, 4096))) >= 0) {
-      byte[] data = new String(buffer, 0, len).getBytes(StandardCharsets.UTF_8);
+      byte[] data = StringUtils.getBytes(new String(buffer, 0, len), StandardCharsets.UTF_8);
       if (escape) {
         writeBytesEscaped(data, data.length, noBackslashEscapes);
       } else {

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
@@ -104,6 +104,7 @@ import org.mariadb.jdbc.internal.util.constant.ParameterConstant;
 import org.mariadb.jdbc.internal.util.constant.ServerStatus;
 import org.mariadb.jdbc.internal.util.exceptions.ExceptionFactory;
 import org.mariadb.jdbc.internal.util.pool.GlobalStateInfo;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 import org.mariadb.jdbc.tls.TlsSocketPlugin;
 import org.mariadb.jdbc.tls.TlsSocketPluginLoader;
 import org.mariadb.jdbc.util.Options;
@@ -111,13 +112,14 @@ import org.mariadb.jdbc.util.Options;
 public abstract class AbstractConnectProtocol implements Protocol {
 
   private static final byte[] SESSION_QUERY =
-      ("SELECT @@max_allowed_packet,"
+      StringUtils.getBytes(
+          ("SELECT @@max_allowed_packet,"
               + "@@system_time_zone,"
               + "@@time_zone,"
-              + "@@auto_increment_increment")
-          .getBytes(StandardCharsets.UTF_8);
+              + "@@auto_increment_increment"),
+          StandardCharsets.UTF_8);
   private static final byte[] IS_MASTER_QUERY =
-      "select @@innodb_read_only".getBytes(StandardCharsets.UTF_8);
+      StringUtils.getBytes("select @@innodb_read_only", StandardCharsets.UTF_8);
   protected static final String CHECK_GALERA_STATE_QUERY = "show status like 'wsrep_local_state'";
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractConnectProtocol.class);

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
@@ -103,6 +103,7 @@ import org.mariadb.jdbc.internal.util.exceptions.MariaDbSqlException;
 import org.mariadb.jdbc.internal.util.exceptions.MaxAllowedPacketException;
 import org.mariadb.jdbc.internal.util.pool.GlobalStateInfo;
 import org.mariadb.jdbc.internal.util.scheduler.SchedulerServiceProviderHolder;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class AbstractQueryProtocol extends AbstractConnectProtocol implements Protocol {
 
@@ -269,7 +270,7 @@ public class AbstractQueryProtocol extends AbstractConnectProtocol implements Pr
 
       writer.startPacket(0);
       writer.write(COM_QUERY);
-      writer.write(sql.getBytes(charset));
+      writer.write(StringUtils.getBytes(sql, charset));
       writer.flush();
       getResult(results);
 
@@ -1655,7 +1656,7 @@ public class AbstractQueryProtocol extends AbstractConnectProtocol implements Pr
       // Pre-4.1 message, still can be output in newer versions (e.g with 'Too many connections')
       buffer.position -= 1;
       message =
-          new String(
+          StringUtils.newString(
               buffer.buf, buffer.position, buffer.limit - buffer.position, StandardCharsets.UTF_8);
       sqlState = "HY000";
     }

--- a/src/main/java/org/mariadb/jdbc/internal/util/dao/ClientPrepareResult.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/dao/ClientPrepareResult.java
@@ -55,6 +55,7 @@ package org.mariadb.jdbc.internal.util.dao;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.mariadb.jdbc.internal.util.string.StringUtils;
 
 public class ClientPrepareResult implements PrepareResult {
 
@@ -186,7 +187,8 @@ public class ClientPrepareResult implements PrepareResult {
         case '?':
           if (state == LexState.Normal) {
             partList.add(
-                queryString.substring(lastParameterPosition, i).getBytes(StandardCharsets.UTF_8));
+                StringUtils.getBytes(
+                    queryString.substring(lastParameterPosition, i), StandardCharsets.UTF_8));
             lastParameterPosition = i + 1;
           }
           break;
@@ -208,12 +210,11 @@ public class ClientPrepareResult implements PrepareResult {
       lastChar = car;
     }
     if (lastParameterPosition == 0) {
-      partList.add(queryString.getBytes(StandardCharsets.UTF_8));
+      partList.add(StringUtils.getBytes(queryString, StandardCharsets.UTF_8));
     } else {
       partList.add(
-          queryString
-              .substring(lastParameterPosition, queryLength)
-              .getBytes(StandardCharsets.UTF_8));
+          StringUtils.getBytes(
+              queryString.substring(lastParameterPosition, queryLength), StandardCharsets.UTF_8));
     }
 
     return new ClientPrepareResult(
@@ -492,7 +493,7 @@ public class ClientPrepareResult implements PrepareResult {
                 sb.insert(0, postValuePart);
                 postValuePart = null;
               }
-              partList.add(sb.toString().getBytes(StandardCharsets.UTF_8));
+              partList.add(StringUtils.getBytes(sb.toString(), StandardCharsets.UTF_8));
               sb.setLength(0);
             }
 
@@ -619,20 +620,24 @@ public class ClientPrepareResult implements PrepareResult {
     if (!hasParam) {
       // permit to have rewrite without parameter
       if (preValuePart1 == null) {
-        partList.add(0, sb.toString().getBytes(StandardCharsets.UTF_8));
+        partList.add(0, StringUtils.getBytes(sb.toString(), StandardCharsets.UTF_8));
         partList.add(1, new byte[0]);
       } else {
-        partList.add(0, preValuePart1.getBytes(StandardCharsets.UTF_8));
-        partList.add(1, sb.toString().getBytes(StandardCharsets.UTF_8));
+        partList.add(0, StringUtils.getBytes(preValuePart1, StandardCharsets.UTF_8));
+        partList.add(1, StringUtils.getBytes(sb.toString(), StandardCharsets.UTF_8));
       }
       sb.setLength(0);
     } else {
       partList.add(
           0,
-          (preValuePart1 == null) ? new byte[0] : preValuePart1.getBytes(StandardCharsets.UTF_8));
+          (preValuePart1 == null)
+              ? new byte[0]
+              : StringUtils.getBytes(preValuePart1, StandardCharsets.UTF_8));
       partList.add(
           1,
-          (preValuePart2 == null) ? new byte[0] : preValuePart2.getBytes(StandardCharsets.UTF_8));
+          (preValuePart2 == null)
+              ? new byte[0]
+              : StringUtils.getBytes(preValuePart2, StandardCharsets.UTF_8));
     }
 
     if (!isInsert) {
@@ -643,9 +648,11 @@ public class ClientPrepareResult implements PrepareResult {
     // if no param, don't add to the list.
     if (hasParam) {
       partList.add(
-          (postValuePart == null) ? new byte[0] : postValuePart.getBytes(StandardCharsets.UTF_8));
+          (postValuePart == null)
+              ? new byte[0]
+              : StringUtils.getBytes(postValuePart, StandardCharsets.UTF_8));
     }
-    partList.add(sb.toString().getBytes(StandardCharsets.UTF_8));
+    partList.add(StringUtils.getBytes(sb.toString(), StandardCharsets.UTF_8));
 
     return new ClientPrepareResult(
         queryString, partList, reWritablePrepare, multipleQueriesPrepare, true);

--- a/src/main/java/org/mariadb/jdbc/internal/util/string/StringUtils.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/string/StringUtils.java
@@ -1,0 +1,24 @@
+package org.mariadb.jdbc.internal.util.string;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+public class StringUtils {
+  private StringUtils() {}
+
+  public static String newString(byte[] bytes, int offset, int length, Charset charset) {
+    try {
+      return new String(bytes, offset, length, charset.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(charset.name() + ": " + e);
+    }
+  }
+
+  public static byte[] getBytes(String string, Charset charset) {
+    try {
+      return string.getBytes(charset.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(charset.name() + ": " + e);
+    }
+  }
+}


### PR DESCRIPTION
String(byte[], int, int, Charset) constructor produces many redundant objects in heap (Decoders/Encoders) due lack of caching.
Using String(byte[], int, int, String) constructor solves this problem.