### PR TITLE
Fix pool.close() issue

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/pool/Pools.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/pool/Pools.java
@@ -70,7 +70,10 @@ public class Pools {
       synchronized (poolMap) {
         if (poolMap.containsKey(pool.getUrlParser())) {
           poolMap.remove(pool.getUrlParser());
-          shutdownExecutor();
+
+          if (poolMap.isEmpty()) {
+            shutdownExecutor();
+          }
         }
       }
     }
@@ -104,17 +107,12 @@ public class Pools {
       for (Pool pool : poolMap.values()) {
         if (poolName.equals(pool.getUrlParser().getOptions().poolName)) {
           try {
-            pool.close();
+            pool.close(); // Pool.close() calls Pools.remove(), which does the rest of the cleanup
           } catch (InterruptedException exception) {
             // eat
           }
-          poolMap.remove(pool.getUrlParser());
           return;
         }
-      }
-
-      if (poolMap.isEmpty()) {
-        shutdownExecutor();
       }
     }
   }


### PR DESCRIPTION
When a pool is closed, it closes and nulls a global executor used by all pools. In some cases, this occurs even if there are still other pools open. Closing pools when the executor is nulled results in an exception:
```
java.lang.NullPointerException: null
	at org.mariadb.jdbc.internal.util.pool.Pools.shutdownExecutor(Pools.java:122)
	at org.mariadb.jdbc.internal.util.pool.Pools.remove(Pools.java:72)
	at org.mariadb.jdbc.internal.util.pool.Pool.close(Pool.java:470)
	at org.mariadb.jdbc.MariaDbPoolDataSource.close(MariaDbPoolDataSource.java:621)
```

I have fixed the problem by ensuring the map of pools is checked for emptiness in all cases.