### PR TITLE
[CONJ-805] >1Byte UTF8 character issue if maxFieldSize is set

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/TextRowProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/rowprotocol/TextRowProtocol.java
@@ -234,8 +234,7 @@ public class TextRowProtocol extends RowProtocol {
     }
 
     if (maxFieldSize > 0) {
-      return new String(buf, pos, Math.min(maxFieldSize * 3, length), StandardCharsets.UTF_8)
-          .substring(0, Math.min(maxFieldSize, length));
+        return new String(buf, pos, Math.min(maxFieldSize, length), StandardCharsets.UTF_8);
     }
 
     return new String(buf, pos, length, StandardCharsets.UTF_8);

--- a/src/test/java/org/mariadb/jdbc/StringUTFTest.java
+++ b/src/test/java/org/mariadb/jdbc/StringUTFTest.java
@@ -1,0 +1,91 @@
+/*
+ *
+ * MariaDB Client for Java
+ *
+ * Copyright (c) 2012-2014 Monty Program Ab.
+ * Copyright (c) 2015-2020 MariaDB Corporation Ab.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to Monty Program Ab info@montyprogram.com.
+ *
+ * This particular MariaDB Client for Java file is work
+ * derived from a Drizzle-JDBC. Drizzle-JDBC file which is covered by subject to
+ * the following copyright and notice provisions:
+ *
+ * Copyright (c) 2009-2011, Marcus Eriksson
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the driver nor the names of its contributors may not be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package org.mariadb.jdbc;
+
+import static org.junit.Assert.*;
+
+import java.sql.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StringUTFTest extends BaseTest {
+
+  /**
+   * Initialization.
+   *
+   * @throws SQLException exception
+   */
+  @BeforeClass()
+  public static void initClass() throws SQLException {
+    createTable(
+        "stringutftest",
+        "id int not null primary key auto_increment, stringutf varchar(40)",
+        "COLLATE='utf8_general_ci'");
+  }
+
+  @Test
+  public void testString() throws SQLException {
+    PreparedStatement ps =
+        sharedConnection.prepareStatement("insert into stringutftest values(null, ?)");
+    ps.setString(1, "śćżźęąółń");
+    ps.execute();
+    Statement stmt = sharedConnection.createStatement();
+    stmt.setMaxFieldSize(40);
+    ResultSet rs = stmt.executeQuery("select * from stringutftest");
+    if (rs.next()) {
+      assertEquals("śćżźęąółń", rs.getString(2));
+    } else {
+      fail("must have a result !");
+    }
+  }
+}


### PR DESCRIPTION
Detected at one of my clients.
They use polish special characters like ść
The length in TextRowProtocol is set to 2 for each of those characters so 4 in our example.
With this the current code 
`return new String(buf, pos, Math.min(maxFieldSize * 3, length), StandardCharsets.UTF_8)
                    .substring(0, Math.min(maxFieldSize, length));`
results into an ArrayOutOfBoundsError at the  substring call.

I added a test case and a quick fix for it.
Travis fails on environment issues. Nothing to do with my change.
