### PR TITLE
Fix - setConfiguration not being called on classes that extend ConfigurableSocketFactory

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/Utils.java
@@ -133,7 +133,7 @@ public class Utils {
         if (socketFactoryClass != null) {
           Constructor<? extends SocketFactory> constructor = socketFactoryClass.getConstructor();
           socketFactory = constructor.newInstance();
-          if (socketFactoryClass.isInstance(ConfigurableSocketFactory.class)) {
+          if (ConfigurableSocketFactory.class.isInstance(socketFactory)) {
             ((ConfigurableSocketFactory) socketFactory).setConfiguration(options, host);
           }
           return socketFactory.createSocket();


### PR DESCRIPTION
In my project, I have a class that extends ConfigurableSocketFactory, but the setConfiguration method is never called. I added a breakpoint to if (socketFactoryClass.isInstance(ConfigurableSocketFactory.class)) {, and the expression was evaluating to false.

From my googling, I landed at https://stackoverflow.com/questions/31083699/java-class-isinstance-always-returns-false, which indicated that the evaluation was being done backwards.

When I evaluated ConfigurableSocketFactory.class.isInstance(socketFactory), the result was true