### PR TITLE
 since array[3] will be uses as a wholepart, in case there will be / in this part, e.g. a linux ca path, it should limit split num

### DIFF
--- a/src/test/java/org/mariadb/jdbc/BaseTest.java
+++ b/src/test/java/org/mariadb/jdbc/BaseTest.java
@@ -528,7 +528,7 @@ public class BaseTest {
     } catch (IOException e) {
       e.printStackTrace();
     }
-    String[] splitValue = connUri.split("/");
+    String[] splitValue = connUri.split("/", 4);
     String[] subarray =
         Arrays.asList(splitValue).subList(3, splitValue.length).toArray(new String[0]);
     String dbAndParameters = String.join("/", subarray);

--- a/src/test/java/org/mariadb/jdbc/failover/BaseMultiHostTest.java
+++ b/src/test/java/org/mariadb/jdbc/failover/BaseMultiHostTest.java
@@ -231,7 +231,7 @@ public class BaseMultiHostTest {
     }
     proxySet.put(proxyType, tcpProxies);
 
-    String[] splitValue = tmpUrl.split("/");
+    String[] splitValue = tmpUrl.split("/", 4);
     String[] subarray =
         Arrays.asList(splitValue).subList(3, splitValue.length).toArray(new String[0]);
     String dbAndParameters = String.join("/", subarray);


### PR DESCRIPTION
 since array[3] will be uses as a wholepart, in case there will be / in this part, e.g. a linux ca path, it should limit split num