### PR TITLE
mysql 8.0 still does not have IS_GENERATED column

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbDatabaseMetaData.java
@@ -1068,9 +1068,7 @@ public class MariaDbDatabaseMetaData implements DatabaseMetaData {
       throw new SQLException("'table' parameter cannot be null in getBestRowIdentifier()");
     }
 
-    boolean hasIsGeneratedCol =
-        (connection.isServerMariaDb() && connection.versionGreaterOrEqual(10, 2, 0))
-            || (!connection.isServerMariaDb() && connection.versionGreaterOrEqual(8, 0, 0));
+    boolean hasIsGeneratedCol = (connection.isServerMariaDb() && connection.versionGreaterOrEqual(10, 2, 0));
 
     String sql =
         "SELECT "


### PR DESCRIPTION
From test, mysql 8.0 still does not have IS_GENERATED column. So the condition should not include 8.0.
Tested version: 8.0.15