### PR TITLE
user must exist and 5.6 does not support the syntax if exists

### DIFF
--- a/src/test/java/org/mariadb/jdbc/CredentialPluginTest.java
+++ b/src/test/java/org/mariadb/jdbc/CredentialPluginTest.java
@@ -70,8 +70,8 @@ public class CredentialPluginTest extends BaseTest {
   @After
   public void after() throws SQLException {
     Statement stmt = sharedConnection.createStatement();
-    stmt.execute("DROP USER IF EXISTS 'identityUser'@'%'");
-    stmt.execute("DROP USER IF EXISTS 'identityUser'@'localhost'");
+    stmt.execute("DROP USER 'identityUser'@'%'");
+    stmt.execute("DROP USER 'identityUser'@'localhost'");
   }
 
   @Test


### PR DESCRIPTION
When test comes to after section, the user must already exist. And this syntax is not supported by MySQL5.6. So I think the if exists condition can be safely removed.