### PR TITLE
Added support for Aurora cluster custom endpoints

### DIFF
--- a/src/main/java/org/mariadb/jdbc/HostAddress.java
+++ b/src/main/java/org/mariadb/jdbc/HostAddress.java
@@ -119,7 +119,7 @@ public class HostAddress {
     if (haMode == HaMode.AURORA) {
       Pattern clusterPattern =
           Pattern.compile(
-              "(.+)\\.(?:cluster-|cluster-ro-)([a-z0-9]+\\.[a-z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+              "(.+)\\.(?:cluster-|cluster-ro-|cluster-custom-)([a-z0-9]+\\.[a-z0-9\\-]+\\.rds\\.amazonaws\\.com)",
               Pattern.CASE_INSENSITIVE);
       Matcher matcher = clusterPattern.matcher(spec);
 

--- a/src/main/java/org/mariadb/jdbc/internal/failover/impl/AuroraListener.java
+++ b/src/main/java/org/mariadb/jdbc/internal/failover/impl/AuroraListener.java
@@ -76,7 +76,7 @@ public class AuroraListener extends MastersReplicasListener {
   private static final Logger logger = Logger.getLogger(AuroraListener.class.getName());
   private final Pattern auroraDnsPattern =
       Pattern.compile(
-          "(.+)\\.(cluster-|cluster-ro-)?([a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
+          "(.+)\\.(cluster-|cluster-ro-|cluster-custom-)?([a-zA-Z0-9]+\\.[a-zA-Z0-9\\-]+\\.rds\\.amazonaws\\.com)",
           Pattern.CASE_INSENSITIVE);
   private final HostAddress clusterHostAddress;
   private String clusterDnsSuffix = null;


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.Endpoints.html#Aurora.Overview.Endpoints.Types

There are three Aurora endpoints: cluster endpoint, reader endpoint, and custom endpoint.

But it didn't support custom endpoint.
This PR corresponds to the URL format of the custom endpoint.

Please let me know if there is anything else to do
