### PR TITLE
ON DUPLICATE KEY clause unnoticed if query includes newlines

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationSingle.java
+++ b/src/main/java/org/mariadb/jdbc/internal/com/read/dao/CmdInformationSingle.java
@@ -137,7 +137,7 @@ public class CmdInformationSingle implements CmdInformation {
   }
 
   private boolean isDuplicateKeyUpdate(String sql) {
-    return sql.matches("(?i).*ON\\s+DUPLICATE\\s+KEY\\s+UPDATE.*");
+    return sql.matches("(?s)(?i).*ON\\s+DUPLICATE\\s+KEY\\s+UPDATE.*");
   }
 
   @Override

--- a/src/test/java/org/mariadb/jdbc/MultiTest.java
+++ b/src/test/java/org/mariadb/jdbc/MultiTest.java
@@ -1418,7 +1418,7 @@ public class MultiTest extends BaseTest {
       }
       try (PreparedStatement pstmt =
           con.prepareStatement(
-              "INSERT INTO testMultiGeneratedKey (id, text) VALUES (?, ?) "
+              "INSERT INTO testMultiGeneratedKey (id, text) \nVALUES (?, ?) "
                   + "ON DUPLICATE KEY UPDATE text = VALUES(text)",
               Statement.RETURN_GENERATED_KEYS)) {
         // Insert a row.


### PR DESCRIPTION
CmdInformationSingle.isDuplicateKeyUpdate() fails to detect ON DUPLICATE KEY clause if there are newlines in query.
Solved by enabling DOTALL mode in regexp.