### PR TITLE
Fixed java.lang.NoClassDefFoundError: javax/sql/rowset/serial/SerialException when using OSGi framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tracker link <a href="https://jira.mariadb.org/projects/CONJ/issues/">https://ji
 
 ## Status
 [![Linux Build](https://travis-ci.com/mariadb-corporation/mariadb-connector-j.svg?branch=master)](https://travis-ci.com/mariadb-corporation/mariadb-connector-j)
-[![Windows Build](https://ci.appveyor.com/api/projects/status/icmwu47dyj05htid/branch/master?svg=true)](https://ci.appveyor.com/project/rusher/mariadb-connector-j-8yinp/branch/master)
+[![Windows Build](https://ci.appveyor.com/api/projects/status/9o4hjqouaq2vp2v4/branch/master?svg=true)](https://ci.appveyor.com/project/mariadb/mariadb-connector-j/branch/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.mariadb.jdbc/mariadb-java-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.mariadb.jdbc/mariadb-java-client)
 [![License (LGPL version 2.1)](https://img.shields.io/badge/license-GNU%20LGPL%20version%202.1-green.svg?style=flat-square)](http://opensource.org/licenses/LGPL-2.1)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/be7f4c89d63e496d824e8f365478e8c8)](https://www.codacy.com/app/diego-dupin/mariadb-connector-j?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MariaDB/mariadb-connector-j&amp;utm_campaign=Badge_Grade)

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
               <Automatic-Module-Name>org.mariadb.jdbc</Automatic-Module-Name>
               <Export-Package>org.mariadb.jdbc</Export-Package>
               <Import-Package>
-                org.osgi.service.jdbc,org.osgi.framework,javax.naming,javax.management,javax.sql,javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.transaction.xa;resolution:=optional,waffle.windows.auth;resolution:=optional,waffle.windows.auth.impl;resolution:=optional,org.ietf.jgss;resolution:=optional,javax.security.auth.login;resolution:=optional
+                org.osgi.service.jdbc,org.osgi.framework,javax.naming,javax.management,javax.sql,javax.sql.rowset.serial,javax.net;resolution:=optional,javax.net.ssl;resolution:=optional,javax.transaction.xa;resolution:=optional,waffle.windows.auth;resolution:=optional,waffle.windows.auth.impl;resolution:=optional,org.ietf.jgss;resolution:=optional,javax.security.auth.login;resolution:=optional
               </Import-Package>
               <Bundle-Activator>org.mariadb.jdbc.internal.osgi.MariaDbActivator</Bundle-Activator>
             </manifestEntries>


### PR DESCRIPTION
We are using Apache Karaf and recently upgraded pax-jdbc-mariadb from version 1.4.5 to 1.5.0. This increased the version of mariadb-java-client from 2.4.4 to 2.7.2. When connecting to a database the bundle crashed with `java.lang.NoClassDefFoundError: javax/sql/rowset/serial/SerialException`. The solution is to add a missing import to pom.xml.