### PR TITLE
CONJ-885 Log any SQLException that occurs while adding connections to pool

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/util/pool/Pool.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/pool/Pool.java
@@ -145,7 +145,7 @@ public class Pool implements AutoCloseable, PoolMBean {
               try {
                 addConnection();
               } catch (SQLException sqle) {
-                // eat
+                logger.error("error adding connection to pool", sqle);
               }
             }
           });


### PR DESCRIPTION
The commit here fixes the issue noted in https://jira.mariadb.org/browse/CONJ-885 where if a `SQLException` occurs while adding a new connection to the pool, then that exception is never reported/logged which can then make it difficult to understand subsequent failures to obtain connection(s) from the `Pool` instance.
