### PR TITLE
CONJ-897 Include connection id in certain important log messages

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractConnectProtocol.java
@@ -398,6 +398,9 @@ public abstract class AbstractConnectProtocol implements Protocol {
 
   /** Force closes socket and stream readers/writers. */
   public void abort() {
+    if (logger.isDebugEnabled()) {
+      logger.debug("aborting connection {}", serverThreadId);
+    }
     this.explicitClosed = true;
 
     boolean lockStatus = false;

--- a/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
+++ b/src/main/java/org/mariadb/jdbc/internal/protocol/AbstractQueryProtocol.java
@@ -1235,7 +1235,8 @@ public class AbstractQueryProtocol extends AbstractConnectProtocol implements Pr
 
     } catch (IOException e) {
       connected = false;
-      throw new SQLNonTransientConnectionException("Could not ping: " + e.getMessage(), "08000", e);
+      throw new SQLNonTransientConnectionException(
+          "Could not ping connection " + serverThreadId + " : " + e.getMessage(), "08000", e);
     } finally {
       lock.unlock();
     }

--- a/src/main/java/org/mariadb/jdbc/internal/util/pool/Pool.java
+++ b/src/main/java/org/mariadb/jdbc/internal/util/pool/Pool.java
@@ -188,14 +188,15 @@ public class Pool implements AutoCloseable, PoolMBean {
       }
 
       if (shouldBeReleased && idleConnections.remove(item)) {
-
+        final long connId = item.getConnection().getServerThreadId();
         totalConnection.decrementAndGet();
         silentCloseConnection(item);
         addConnectionRequest();
         if (logger.isDebugEnabled()) {
           logger.debug(
-              "pool {} connection removed due to inactivity (total:{}, active:{}, pending:{})",
+              "pool {} connection {} removed due to inactivity (total:{}, active:{}, pending:{})",
               poolTag,
+              connId,
               totalConnection.get(),
               getActiveConnections(),
               pendingRequestNumber.get());
@@ -234,8 +235,9 @@ public class Pool implements AutoCloseable, PoolMBean {
 
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "pool {} new physical connection created (total:{}, active:{}, pending:{})",
+            "pool {} new physical connection {} created (total:{}, active:{}, pending:{})",
             poolTag,
+            connection.getServerThreadId(),
             totalConnection.get(),
             getActiveConnections(),
             pendingRequestNumber.get());
@@ -266,6 +268,7 @@ public class Pool implements AutoCloseable, PoolMBean {
 
       if (item != null) {
         MariaDbConnection connection = item.getConnection();
+        final long connId = connection.getServerThreadId();
         try {
           if (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - item.getLastUsed().get())
               > options.poolValidMinDelay) {
@@ -292,8 +295,9 @@ public class Pool implements AutoCloseable, PoolMBean {
         addConnectionRequest();
         if (logger.isDebugEnabled()) {
           logger.debug(
-              "pool {} connection removed from pool due to failed validation (total:{}, active:{}, pending:{})",
+              "pool {} connection {} removed from pool due to failed validation (total:{}, active:{}, pending:{})",
               poolTag,
+              connId,
               totalConnection.get(),
               getActiveConnections(),
               pendingRequestNumber.get());


### PR DESCRIPTION
As noted in https://jira.mariadb.org/browse/CONJ-897, the commit in this PR enhances certain log messages to print out the connection id. This change helped us in a big way to narrow down the issue noted in https://jira.mariadb.org/browse/CONJ-896.