### PR TITLE
Upgrading Logback 1.3.0-alpha11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <logback.version>1.3.0-alpha10</logback.version>
+        <logback.version>1.3.0-alpha11</logback.version>
         <jacoco.version>0.8.7</jacoco.version>
         <waffle-jna.version>3.0.0</waffle-jna.version>
         <mysql-connector-java.version>8.0.27</mysql-connector-java.version>


### PR DESCRIPTION
In light of the recent news related to Log4j, Logback fixed a security vulnerability in 1.3.0-alpha11. More info at http://mailman.qos.ch/pipermail/logback-user/2021-December/005168.html