### PR TITLE
Fix for https://jira.mariadb.org/browse/CONJ-925

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,13 @@
+Export-Package: org.mariadb.jdbc
+
+Import-Package: \
+  com.sun.jna;\
+  com.sun.jna.platform.win32;resolution:=optional,\
+  software.amazon.awssdk.*;resolution:=optional,\
+  waffle.windows.auth;\
+  waffle.windows.auth.impl;resolution:=optional,\
+  org.slf4j;version="[1.7,2.0)";resolution:=optional, \
+  org.ietf.jgss;resolution:=optional, \
+  *
+
+-fixupmessages: "Classes found in the wrong directory:";is:=ignore

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -6,7 +6,7 @@ Import-Package: \
   software.amazon.awssdk.*;resolution:=optional,\
   waffle.windows.auth;\
   waffle.windows.auth.impl;resolution:=optional,\
-  org.slf4j;version="[1.7,2.0)";resolution:=optional, \
+  org.slf4j;version="[1.7,3.0)";resolution:=optional, \
   org.ietf.jgss;resolution:=optional, \
   *
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <jacoco.version>0.8.7</jacoco.version>
         <waffle-jna.version>3.1.1</waffle-jna.version>
         <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
+        <bnd-maven-plugin.version>6.1.0</bnd-maven-plugin.version>
     </properties>
 
     <licenses>
@@ -177,6 +178,7 @@
                         <manifestEntries>
                             <Multi-Release>true</Multi-Release>
                         </manifestEntries>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -243,6 +245,22 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+            </plugin>
+
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>${bnd-maven-plugin.version}</version>
+                <configuration>
+                    <bndfile>bnd.bnd</bndfile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
Added the OSGi metadata using the bnd-maven-plugin. The resultant jar is an OSGi bundle now and deploys correctly to OSGi runtime.