### PR TITLE
Repair the bug for ArrayIndexOutOfBoundsException:

### DIFF
--- a/src/main/java/org/mariadb/jdbc/internal/io/output/AbstractPacketOutputStream.java
+++ b/src/main/java/org/mariadb/jdbc/internal/io/output/AbstractPacketOutputStream.java
@@ -730,7 +730,10 @@ public abstract class AbstractPacketOutputStream extends FilterOutputStream
           }
 
         } else {
-
+          // if buffer can't grows and space is full, need flush at first
+          if(buf.length <= pos) {
+        	flushBuffer(false);
+      	  }
           // not enough space in buffer, will fill buffer
           if (noBackslashEscapes) {
             for (int i = 0; i < len; i++) {


### PR DESCRIPTION
Fix the bug for exception while buffer can't grows, the pos has been added 1 that it is exceed buf length.
java.lang.ArrayIndexOutOfBoundsException: 16777219
	at org.mariadb.jdbc.internal.io.output.AbstractPacketOutputStream.writeBytesEscaped(AbstractPacketOutputStream.java:759)
	at org.mariadb.jdbc.internal.io.output.AbstractPacketOutputStream.write(AbstractPacketOutputStream.java:507)
	at org.mariadb.jdbc.internal.com.send.parameters.StringParameter.writeTo(StringParameter.java:76)
	at org.mariadb.jdbc.internal.com.send.ComQuery.sendSubCmd(ComQuery.java:89)
	at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:315)
	at org.mariadb.jdbc.ClientSidePreparedStatement.executeInternal(ClientSidePreparedStatement.java:220)
	at org.mariadb.jdbc.ClientSidePreparedStatement.execute(ClientSidePreparedStatement.java:149)
	at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3461)
	at com.alibaba.druid.filter.FilterEventAdapter.preparedStatement_execute(FilterEventAdapter.java:440)
	at com.alibaba.druid.filter.FilterChainImpl.preparedStatement_execute(FilterChainImpl.java:3459)
	at com.alibaba.druid.proxy.jdbc.PreparedStatementProxyImpl.execute(PreparedStatementProxyImpl.java:167)
	at com.alibaba.druid.pool.DruidPooledPreparedStatement.execute(DruidPooledPreparedStatement.java:497)
	at org.apache.ibatis.executor.statement.PreparedStatementHandler.update(PreparedStatementHandler.java:47)
	at org.apache.ibatis.executor.statement.RoutingStatementHandler.update(RoutingStatementHandler.java:74)
	at org.apache.ibatis.executor.SimpleExecutor.doUpdate(SimpleExecutor.java:50)