### PR TITLE
Prevent NPE on missing properties

### DIFF
--- a/src/main/java/org/mariadb/jdbc/util/VersionFactory.java
+++ b/src/main/java/org/mariadb/jdbc/util/VersionFactory.java
@@ -21,10 +21,11 @@ public final class VersionFactory {
               Version.class.getClassLoader().getResourceAsStream("mariadb.properties")) {
             if (inputStream == null) {
               System.out.println("property file 'mariadb.properties' not found in the classpath");
+            } else {
+              Properties prop = new Properties();
+              prop.load(inputStream);
+              tmpVersion = prop.getProperty("version");
             }
-            Properties prop = new Properties();
-            prop.load(inputStream);
-            tmpVersion = prop.getProperty("version");
           } catch (IOException e) {
             e.printStackTrace();
           }

--- a/src/test/java/org/mariadb/jdbc/unit/util/VersionFactoryTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/util/VersionFactoryTest.java
@@ -1,0 +1,18 @@
+package org.mariadb.jdbc.unit.util;
+
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.util.Version;
+import org.mariadb.jdbc.util.VersionFactory;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VersionFactoryTest {
+
+    @Test
+    public void testGetInstance() {
+        Version actual = VersionFactory.getInstance();
+
+        assertNotNull(actual);
+    }
+
+}


### PR DESCRIPTION
Prevent loading properties from 'mariadb.properties' if the file is not found.

Without this commit, a Null Pointer Exception is thrown when `org.mariadb.jdbc.util.VersionFactory.getInstance()` is called and the properties file is missing.

With this commit, the Version will fallback to the `tmpVersion` of "5.5.0", which looks to be the intended behavior of this class.