### PR TITLE
[CONJ-1053] Make the JPMS requirement on waffle-jna static

### DIFF
--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -6,7 +6,7 @@ module org.mariadb.jdbc {
   requires transitive java.naming;
   requires transitive java.security.jgss;
   requires transitive jdk.net;
-  requires waffle.jna;
+  requires static waffle.jna;
   requires static software.amazon.awssdk.services.rds;
   requires static software.amazon.awssdk.regions;
   requires static software.amazon.awssdk.auth;


### PR DESCRIPTION
The waffle-jna dependency is needed only when Windows GSSAPI authentication is used. In a previous commit, the `static` was incorrectly removed, making the dependency a hard requirement when running on JPMS.

https://github.com/mariadb-corporation/mariadb-connector-j/commit/5ac67b2d17dcf4e0272781426d67299dedf5a377

However, maven is not the same as JPMS. An optional dependency via Maven *is not* the same as `requires static` in JPMS. They serve entirely different purposes. By removing `requires static`, you are saying that all deployments *must* have waffle-jna present on the module path.

Re-adding `requires static` will not affect existing clients using MariaDB Connector-J. If they used waffla-jna before, they will continue to use it after this change.

https://jira.mariadb.org/browse/CONJ-1053