### PR TITLE
Fix unsigned jdbc types

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/column/UnsignedIntColumn.java
+++ b/src/main/java/org/mariadb/jdbc/client/column/UnsignedIntColumn.java
@@ -66,7 +66,7 @@ public class UnsignedIntColumn extends ColumnDefinitionPacket implements ColumnD
   }
 
   public int getColumnType(final Configuration conf) {
-    return Types.BIGINT;
+    return Types.INTEGER;
   }
 
   public String getColumnTypeName(final Configuration conf) {

--- a/src/main/java/org/mariadb/jdbc/client/column/UnsignedSmallIntColumn.java
+++ b/src/main/java/org/mariadb/jdbc/client/column/UnsignedSmallIntColumn.java
@@ -66,7 +66,7 @@ public class UnsignedSmallIntColumn extends ColumnDefinitionPacket implements Co
   }
 
   public int getColumnType(final Configuration conf) {
-    return Types.INTEGER;
+    return Types.SMALLINT;
   }
 
   public String getColumnTypeName(final Configuration conf) {

--- a/src/main/java/org/mariadb/jdbc/client/column/UnsignedTinyIntColumn.java
+++ b/src/main/java/org/mariadb/jdbc/client/column/UnsignedTinyIntColumn.java
@@ -70,7 +70,7 @@ public class UnsignedTinyIntColumn extends ColumnDefinitionPacket implements Col
     if (conf.tinyInt1isBit() && columnLength == 1) {
       return conf.transformedBitIsBoolean() ? Types.BOOLEAN : Types.BIT;
     }
-    return Types.SMALLINT;
+    return Types.TINYINT;
   }
 
   public String getColumnTypeName(final Configuration conf) {

--- a/src/test/java/org/mariadb/jdbc/integration/codec/IntCodecTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/codec/IntCodecTest.java
@@ -971,7 +971,7 @@ public class IntCodecTest extends CommonCodecTest {
     assertEquals("java.lang.Long", meta.getColumnClassName(1));
     assertEquals("t1alias", meta.getColumnLabel(1));
     assertEquals("t1", meta.getColumnName(1));
-    assertEquals(Types.BIGINT, meta.getColumnType(1));
+    assertEquals(Types.INTEGER, meta.getColumnType(1));
     assertEquals(4, meta.getColumnCount());
     assertEquals(10, meta.getPrecision(1));
     assertEquals(0, meta.getScale(1));

--- a/src/test/java/org/mariadb/jdbc/integration/codec/SmallIntCodecTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/codec/SmallIntCodecTest.java
@@ -923,7 +923,7 @@ public class SmallIntCodecTest extends CommonCodecTest {
     assertEquals("java.lang.Integer", meta.getColumnClassName(1));
     assertEquals("t1alias", meta.getColumnLabel(1));
     assertEquals("t1", meta.getColumnName(1));
-    assertEquals(Types.INTEGER, meta.getColumnType(1));
+    assertEquals(Types.SMALLINT, meta.getColumnType(1));
     assertEquals(4, meta.getColumnCount());
     assertEquals(5, meta.getPrecision(1));
     assertEquals(0, meta.getScale(1));

--- a/src/test/java/org/mariadb/jdbc/integration/codec/TinyIntCodecTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/codec/TinyIntCodecTest.java
@@ -941,7 +941,7 @@ public class TinyIntCodecTest extends CommonCodecTest {
     assertEquals("java.lang.Integer", meta.getColumnClassName(1));
     assertEquals("t1alias", meta.getColumnLabel(1));
     assertEquals("t1", meta.getColumnName(1));
-    assertEquals(Types.SMALLINT, meta.getColumnType(1));
+    assertEquals(Types.TINYINT, meta.getColumnType(1));
     assertEquals(4, meta.getColumnCount());
     assertEquals(3, meta.getPrecision(1));
     assertEquals(0, meta.getScale(1));

--- a/src/test/java/org/mariadb/jdbc/integration/resultset/ResultSetMetadataTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/resultset/ResultSetMetadataTest.java
@@ -67,7 +67,7 @@ public class ResultSetMetadataTest extends Common {
     if (!isXpand()) {
       assertEquals(Types.CHAR, rsmd.getColumnType(4));
     }
-    assertEquals(Types.INTEGER, rsmd.getColumnType(5));
+    assertEquals(Types.SMALLINT, rsmd.getColumnType(5));
     assertFalse(rsmd.isReadOnly(1));
     assertFalse(rsmd.isReadOnly(2));
     assertTrue(rsmd.isWritable(1));


### PR DESCRIPTION
1.The pr aims to fix unsigned jdbc types, include:
- UnsignedIntColumn from `Types.BIGINT` to `Types.INTEGER`
- UnsignedSmallIntColumn from `Types.INTEGER` to `Types.SMALLINT`
- UnsignedTinyIntColumn from `Types.SMALLINT` to `Types.TINYINT`

2.why?
When we recently migrated `mariadb-connector-j` from `2.x` to `3.x` in Spark and used `mariadb-connector-j` to access `MySQL` data, We found that 'java. sql.Types' returned by some `unsigned` jdbc types of '2.x ' and ' 3.x ' are inconsistent, as follows:
|Column Type Define|2.x|3.x|
|---|---|---|
|TINYINT UNSIGNED|Types.TINYINT|Types.SMALLINT|
|SMALLINT UNSIGNE|Types.SMALLINT|Types.INTEGER|
|INT UNSIGNED|Types.INTEGER|Types.BIGINT|

```scala
val dataType = resultSetMetaData.getColumnType(i)
```

3.The `data type` is generally determined by two `attributes`: `ColumnType` and `isSigned`


