### PR TITLE
Correct license id in pom.xml to LGPL-2.1-or-later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <licenses>
         <license>
-            <name>LGPL-2.1</name>
+            <name>LGPL-2.1-or-later</name>
         </license>
     </licenses>
 


### PR DESCRIPTION
License name in pom.xml is recommended to be valid SPDX license id.