### PR TITLE
Socket connections now try all possible IP addresses

### DIFF
--- a/src/main/java/org/mariadb/jdbc/client/impl/ConnectionHelper.java
+++ b/src/main/java/org/mariadb/jdbc/client/impl/ConnectionHelper.java
@@ -5,6 +5,7 @@ package org.mariadb.jdbc.client.impl;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.sql.SQLException;
@@ -109,11 +110,24 @@ public final class ConnectionHelper {
       socket = createSocket(conf, hostAddress);
       SocketHelper.setSocketOption(conf, socket);
       if (!socket.isConnected()) {
-        InetSocketAddress sockAddr =
-            hostAddress.pipe == null && hostAddress.localSocket == null
-                ? new InetSocketAddress(hostAddress.host, hostAddress.port)
-                : null;
-        socket.connect(sockAddr, conf.connectTimeout());
+        boolean isLocalSocket = hostAddress.pipe == null && hostAddress.localSocket == null;
+        if (isLocalSocket) {
+          socket.connect(null, conf.connectTimeout());
+        } else {
+          InetAddress[] allAddress = InetAddress.getAllByName(hostAddress.host);
+          IOException lastException = null;
+          for (InetAddress address : allAddress) {
+              try {
+                socket.connect(new InetSocketAddress(address, hostAddress.port), conf.connectTimeout());
+                break;
+              }catch (IOException ignore) {
+                lastException = ignore;
+              }
+          }
+          if (lastException != null) {
+            throw lastException;
+          }
+        }
       }
       return socket;
 


### PR DESCRIPTION
Fixed an issue in ConnectionHelper where Socket connections sometimes failed. Socket connections now try all possible IP addresses, not just the first one. 

When a host has multiple IP resolution results, especially when the results include both IPv4 and IPv6 addresses, this change can help connect to the correct IP. 

For example, if the server is listening on ::1 and the client uses `localhost` to connect, by default, it will only attempt to connect to 127.0.0.1