### PR TITLE
Use 32760 as the "unused" port number

### DIFF
--- a/src/test/java/org/mariadb/jdbc/integration/ErrorTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/ErrorTest.java
@@ -149,7 +149,8 @@ public class ErrorTest extends Common {
   @Test
   public void connectionErrorFormat() throws SQLException {
     try {
-      DriverManager.getConnection("jdbc:mariadb://localhost:3000/db");
+      // Port 32760 should hopefully not have a MariaDB instance running on it.
+      DriverManager.getConnection("jdbc:mariadb://localhost:32760/db");
       fail("Must have thrown an error");
     } catch (SQLException e) {
       assertEquals("08000", e.getSQLState());


### PR DESCRIPTION
Port 3000 is not that uncommon of a port for a MariaDB instance to run on. To avoid conflicting with setups where there actually is a MariaDB instance running on that port, use a port that is near the end of the ephemeral range. Hopefully this is something that is less likely to conflict.