### PR TITLE
Fixing flaky configuration tests

### DIFF
--- a/src/main/java/org/mariadb/jdbc/Configuration.java
+++ b/src/main/java/org/mariadb/jdbc/Configuration.java
@@ -1039,9 +1039,13 @@ public class Configuration {
     if (conf.nonMappedOptions.isEmpty()) {
       sbUnknownOpts.append("None");
     } else {
-      for (Map.Entry<Object, Object> entry : conf.nonMappedOptions.entrySet()) {
-        sbUnknownOpts.append("\n * ").append(entry.getKey()).append(" : ").append(entry.getValue());
-      }
+      conf.nonMappedOptions.entrySet().stream()
+              .map(entry -> new AbstractMap.SimpleEntry<>(
+                      entry.getKey().toString(),
+                      entry.getValue() != null ? entry.getValue().toString() : ""
+              ))
+              .sorted(Map.Entry.comparingByKey())
+              .forEach(entry -> sbUnknownOpts.append("\n * ").append(entry.getKey()).append(" : ").append(entry.getValue()));
     }
     sb.append("Configuration:")
         .append("\n * resulting Url : ")

--- a/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java
+++ b/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java
@@ -7,7 +7,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mariadb.jdbc.*;
@@ -87,8 +91,8 @@ public class ConfigurationTest {
         "jdbc:mariadb://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?user=me&password=***&timezone=UTC&autocommit=false&useCatalogTerm=SCHEMA&createDatabaseIfNotExist=true&useLocalSessionState=true&returnMultiValuesGeneratedIds=true&permitRedirect=false&transactionIsolation=REPEATABLE_READ&defaultFetchSize=10&maxQuerySizeToLog=100&maxAllowedPacket=8000&geometryDefaultType=default&restrictedAuth=mysql_native_password,client_ed25519&initSql=SET"
             + " @@a='10'&socketFactory=someSocketFactory&connectTimeout=22&pipe=pipeName&localSocket=localSocket&uuidAsString=true&tcpKeepAlive=false&tcpKeepIdle=10&tcpKeepCount=50&tcpKeepInterval=50&tcpAbortiveClose=true&localSocketAddress=localSocketAddress&socketTimeout=1000&useReadAheadInput=true&tlsSocketType=TLStype&sslMode=TRUST&serverSslCert=mycertPath&keyStore=/tmp&keyStorePassword=MyPWD&keyStoreType=JKS&trustStoreType=JKS&enabledSslCipherSuites=myCipher,cipher2&enabledSslProtocolSuites=TLSv1.2&allowMultiQueries=true&allowLocalInfile=false&useCompression=true&useAffectedRows=true&disablePipeline=true&cachePrepStmts=false&prepStmtCacheSize=2&useServerPrepStmts=true&credentialType=ENV&sessionVariables=blabla&connectionAttributes=bla=bla&servicePrincipalName=SPN&blankTableNameMeta=true&tinyInt1isBit=false&yearIsDateType=false&dumpQueriesOnException=true&includeInnodbStatusInDeadlockExceptions=true&includeThreadDumpInDeadlockExceptions=true&retriesAllDown=10&galeraAllowedState=A,B&transactionReplay=true&pool=true&poolName=myPool&maxPoolSize=16&minPoolSize=12&maxIdleTime=25000&registerJmxPool=false&poolValidMinDelay=260&useResetConnection=true&serverRsaPublicKeyFile=RSAPath&allowPublicKeyRetrieval=true";
     assertEquals(
-        Configuration.parse(allOptionSet).toString(),
-        Configuration.parse(allOptionSet).toBuilder().build().toString());
+        normalizeConnectionString(Configuration.parse(allOptionSet).toString()),
+        normalizeConnectionString(Configuration.parse(allOptionSet).toBuilder().build().toString()));
   }
 
   @Test
@@ -952,10 +956,10 @@ public class ConfigurationTest {
             .trustStoreType("jks")
             .build();
     String expected =
-        "jdbc:mariadb://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?user=me&password=***&timezone=UTC&connectionCollation=utf8mb4_vietnamese_ci&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=false&preserveInstants=true&autocommit=false&nullDatabaseMeansCurrent=true&useCatalogTerm=SCHEMA&createDatabaseIfNotExist=true&useLocalSessionState=true&returnMultiValuesGeneratedIds=true&permitRedirect=false&transactionIsolation=REPEATABLE_READ&defaultFetchSize=10&maxQuerySizeToLog=100&maxAllowedPacket=8000&geometryDefaultType=default&restrictedAuth=mysql_native_password,client_ed25519&initSql=SET"
-            + " @@a='10'&socketFactory=someSocketFactory&connectTimeout=22&uuidAsString=true&tcpKeepAlive=false&tcpKeepIdle=10&tcpKeepCount=50&tcpKeepInterval=50&tcpAbortiveClose=true&localSocketAddress=localSocketAddress&socketTimeout=1000&useReadAheadInput=true&tlsSocketType=TLStype&sslMode=TRUST&serverSslCert=mycertPath&keyStore=/tmp&trustStore=/tmp/file&keyStorePassword=***&trustStorePassword=***&keyStoreType=JKS&trustStoreType=jks&enabledSslCipherSuites=myCipher,cipher2&enabledSslProtocolSuites=TLSv1.2&fallbackToSystemKeyStore=false&fallbackToSystemTrustStore=false&allowMultiQueries=true&allowLocalInfile=false&useCompression=true&useAffectedRows=true&useBulkStmts=true&disablePipeline=true&cachePrepStmts=false&prepStmtCacheSize=2&useServerPrepStmts=true&credentialType=ENV&sessionVariables=blabla&connectionAttributes=bla=bla&servicePrincipalName=SPN&blankTableNameMeta=true&tinyInt1isBit=false&yearIsDateType=false&dumpQueriesOnException=true&includeInnodbStatusInDeadlockExceptions=true&includeThreadDumpInDeadlockExceptions=true&retriesAllDown=10&galeraAllowedState=A,B&transactionReplay=true&pool=true&poolName=myPool&maxPoolSize=16&minPoolSize=12&maxIdleTime=25000&registerJmxPool=false&poolValidMinDelay=260&useResetConnection=true&serverRsaPublicKeyFile=RSAPath&allowPublicKeyRetrieval=true";
-    assertEquals(expected, conf.toString());
-    assertEquals(expected, conf.toBuilder().build().toString());
+        normalizeConnectionString("jdbc:mariadb://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?user=me&password=***&timezone=UTC&connectionCollation=utf8mb4_vietnamese_ci&connectionTimeZone=SERVER&forceConnectionTimeZoneToSession=false&preserveInstants=true&autocommit=false&nullDatabaseMeansCurrent=true&useCatalogTerm=SCHEMA&createDatabaseIfNotExist=true&useLocalSessionState=true&returnMultiValuesGeneratedIds=true&permitRedirect=false&transactionIsolation=REPEATABLE_READ&defaultFetchSize=10&maxQuerySizeToLog=100&maxAllowedPacket=8000&geometryDefaultType=default&restrictedAuth=mysql_native_password,client_ed25519&initSql=SET"
+            + " @@a='10'&socketFactory=someSocketFactory&connectTimeout=22&uuidAsString=true&tcpKeepAlive=false&tcpKeepIdle=10&tcpKeepCount=50&tcpKeepInterval=50&tcpAbortiveClose=true&localSocketAddress=localSocketAddress&socketTimeout=1000&useReadAheadInput=true&tlsSocketType=TLStype&sslMode=TRUST&serverSslCert=mycertPath&keyStore=/tmp&trustStore=/tmp/file&keyStorePassword=***&trustStorePassword=***&keyStoreType=JKS&trustStoreType=jks&enabledSslCipherSuites=myCipher,cipher2&enabledSslProtocolSuites=TLSv1.2&fallbackToSystemKeyStore=false&fallbackToSystemTrustStore=false&allowMultiQueries=true&allowLocalInfile=false&useCompression=true&useAffectedRows=true&useBulkStmts=true&disablePipeline=true&cachePrepStmts=false&prepStmtCacheSize=2&useServerPrepStmts=true&credentialType=ENV&sessionVariables=blabla&connectionAttributes=bla=bla&servicePrincipalName=SPN&blankTableNameMeta=true&tinyInt1isBit=false&yearIsDateType=false&dumpQueriesOnException=true&includeInnodbStatusInDeadlockExceptions=true&includeThreadDumpInDeadlockExceptions=true&retriesAllDown=10&galeraAllowedState=A,B&transactionReplay=true&pool=true&poolName=myPool&maxPoolSize=16&minPoolSize=12&maxIdleTime=25000&registerJmxPool=false&poolValidMinDelay=260&useResetConnection=true&serverRsaPublicKeyFile=RSAPath&allowPublicKeyRetrieval=true");
+    assertEquals(expected, normalizeConnectionString(conf.toString()));
+    assertEquals(expected, normalizeConnectionString(conf.toBuilder().build().toString()));
   }
 
   @Test
@@ -1026,12 +1030,12 @@ public class ConfigurationTest {
                     + "\n"
                     + "default options :"));
     assertTrue(
-        Configuration.toConf(
-                "jdbc:mariadb:loadbalance://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?nonExisting&nonExistingWithValue=tt&user=me&password=***&autocommit=false&createDatabaseIfNotExist=true&")
+        normalizeConfigurationString(Configuration.toConf(
+                "jdbc:mariadb:loadbalance://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?nonExisting&nonExistingWithValue=tt&user=me&password=***&autocommit=false&createDatabaseIfNotExist=true&"))
             .startsWith(
                 "Configuration:\n"
                     + " * resulting Url :"
-                    + " jdbc:mariadb:loadbalance://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?user=me&password=***&nonExisting=&nonExistingWithValue=tt&autocommit=false&createDatabaseIfNotExist=true\n"
+                    + " " + normalizeConnectionString("jdbc:mariadb:loadbalance://host1:3305,address=(host=host2)(port=3307)(type=replica)/db?user=me&password=***&nonExisting=&nonExistingWithValue=tt&autocommit=false&createDatabaseIfNotExist=true") + "\n"
                     + "Unknown options : \n"
                     + " * nonExisting : \n"
                     + " * nonExistingWithValue : tt\n"
@@ -1051,12 +1055,12 @@ public class ConfigurationTest {
                     + " * allowPublicKeyRetrieval : false"));
 
     assertTrue(
-        Configuration.toConf(
-                "jdbc:mariadb://localhost/test?user=root&sslMode=verify-ca&serverSslCert=/tmp/t.pem&trustStoreType=JKS&keyStore=/tmp/keystore&keyStorePassword=kspass")
+        normalizeConfigurationString(Configuration.toConf(
+                "jdbc:mariadb://localhost/test?user=root&sslMode=verify-ca&serverSslCert=/tmp/t.pem&trustStoreType=JKS&keyStore=/tmp/keystore&keyStorePassword=kspass"))
             .startsWith(
                 "Configuration:\n"
                     + " * resulting Url :"
-                    + " jdbc:mariadb://localhost/test?user=root&sslMode=VERIFY_CA&serverSslCert=/tmp/t.pem&keyStore=/tmp/keystore&keyStorePassword=***&trustStoreType=JKS\n"
+                    + " " + normalizeConnectionString("jdbc:mariadb://localhost/test?user=root&sslMode=VERIFY_CA&serverSslCert=/tmp/t.pem&keyStore=/tmp/keystore&keyStorePassword=***&trustStoreType=JKS") + "\n"
                     + "Unknown options : None\n"
                     + "\n"
                     + "Non default options : \n"
@@ -1071,5 +1075,32 @@ public class ConfigurationTest {
                     + "default options :\n"
                     + " * addresses : [localhost]\n"
                     + " * allowLocalInfile : true"));
+  }
+
+  private String normalizeConfigurationString(String configString) {
+    String[] lines = configString.split("\n");
+    StringBuilder newConfig = new StringBuilder();
+    for (String line : lines) {
+      if (line.startsWith(" * resulting Url :")) {
+        String url = line.substring(" * resulting Url :".length()).trim();
+        newConfig.append(" * resulting Url : ").append(normalizeConnectionString(url)).append("\n");
+      } else {
+        newConfig.append(line).append("\n");
+      }
+    }
+    return newConfig.toString();
+  }
+
+  private String normalizeConnectionString(String connectionString) {
+    String[] parts = connectionString.split("\\?", 2);
+    if (parts.length < 2) {
+      return connectionString;
+    }
+    List<String> paramList = Arrays.asList(parts[1].split("&"));
+    String sortedParams = paramList.stream()
+            .map(param -> param.contains("=") ? param : param + "=")
+            .sorted()
+            .collect(Collectors.joining("&"));
+    return parts[0] + "?" + sortedParams;
   }
 }


### PR DESCRIPTION
## Description

This Pull Request is intend to fix flakiness in the following tests in [org.mariadb.jdbc.unit.util.ConfigurationTest](https://github.com/mariadb-corporation/mariadb-connector-j/blob/9c2db3bee043c71755a35ace70fde10c8fffa6a9/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java#L20)

1. [org.mariadb.jdbc.unit.util.ConfigurationTest#testBuild](https://github.com/mariadb-corporation/mariadb-connector-j/blob/9c2db3bee043c71755a35ace70fde10c8fffa6a9/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java#L81)
2. [org.mariadb.jdbc.unit.util.ConfigurationTest#builder](https://github.com/mariadb-corporation/mariadb-connector-j/blob/9c2db3bee043c71755a35ace70fde10c8fffa6a9/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java#L869)
3. [org.mariadb.jdbc.unit.util.ConfigurationTest#toConf](https://github.com/mariadb-corporation/mariadb-connector-j/blob/9c2db3bee043c71755a35ace70fde10c8fffa6a9/src/test/java/org/mariadb/jdbc/unit/util/ConfigurationTest.java#L1016)

These tests fail intermittently when executed with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) plugin due to non-deterministic ordering of properties. The failure logs are attached for reference:

- [ConfigurationTest_java_nondex_output.log](https://github.com/user-attachments/files/17807624/ConfigurationTest_java_nondex_output.log)

### Cause of the Issue:

The failures occur because the tests compare expected strings with actual strings generated from the `Configuration` object. The ordering of query parameters and non-mapped options in these strings is non-deterministic due to the use of `java.util.Properties`, which does not guarantee order. This leads to mismatches in the expected and actual outputs during assertions.

### Fix

All three tests (`testBuild`, `builder`, and `toConf`) fail because they perform assertions comparing expected strings to actual strings generated from the `Configuration` object. However, the ordering of query parameters in the connection string is non-deterministic due to the use of `java.util.Properties`, which does not guarantee the order of its elements. This nondeterminism leads to mismatches during assertions, causing the tests to fail.

To resolve this issue for the first two tests (`testBuild` and `builder`), we introduced a new method called `normalizeConnectionString()`. This method parses the connection string, extracts the query parameters, sorts them lexicographically, and reconstructs the string with the sorted parameters. By fixing the order of the query parameters, these tests now pass consistently. For the third test (`toConf`), we addressed the same issue by introducing a new method called `normalizeConfigurationString()`. This method ensures that `normalizeConnectionString()` is called on the URL generated within the configuration that the `toConf` test checks, thereby standardizing the ordering of query parameters and allowing the test to pass reliably.

In addition to the above issue, the `toConf` test fails occasionally because the `conf.nonMappedOptions` (unknown options) in `org.mariadb.jdbc.Configuration#toConf` are unordered. Although the method ensures that other option types (non-default options, default options) are ordered, the unordered `nonMappedOptions` lead to inconsistent outputs during assertions, causing the test to fail. To fix this, we modified the `toConf` method to sort the `conf.nonMappedOptions`, ensuring consistent ordering and eliminating the flakiness in the `toConf` test.

PS: Instead of sorting the `conf.nonMappedOptions` in `org.mariadb.jdbc.Configuration#toConf`, I can also implement a fix wherein the test is made flexible to accept a configuration string that contains the desired options in any order.

Please let me know if any other changes are required. Thanks!