### PR TITLE
Bump `com.github.waffle:waffle-jna` from 3.3.0 to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <logback.version>1.5.6</logback.version>
         <logback-java8.version>1.3.12</logback-java8.version>
         <jacoco.version>0.8.12</jacoco.version>
-        <waffle-jna.version>3.3.0</waffle-jna.version>
+        <waffle-jna.version>3.5.0</waffle-jna.version>
         <mysql-connector-java.version>8.4.0</mysql-connector-java.version>
         <bnd-maven-plugin.version>6.4.0</bnd-maven-plugin.version>
         <spotless.version>2.43.0</spotless.version>


### PR DESCRIPTION
Dependency `com.github.waffle:waffle-jna` 3.3.0 pulls `com.github.ben-manes.caffeine:caffeine` 2.9.3 which is the last version in the 2.x release train from December 2021. As many other libraries rely on the 3.x release train, this can lead to conflicting transitive  dependencies. Waffle 3.4.0 already is on caffeine 3.x but I thought going with the latest version 3.5.0 is sufficient.