### PR TITLE
Speed up concurrent pool creation

### DIFF
--- a/src/main/java/org/mariadb/jdbc/pool/Pool.java
+++ b/src/main/java/org/mariadb/jdbc/pool/Pool.java
@@ -534,8 +534,10 @@ public class Pool implements AutoCloseable, PoolMBean {
     String jmxName = poolTag.replace(":", "_");
     ObjectName name = new ObjectName("org.mariadb.jdbc.pool:type=" + jmxName);
 
-    if (!mbs.isRegistered(name)) {
-      mbs.registerMBean(this, name);
+    synchronized (mbs) {
+      if (!mbs.isRegistered(name)) {
+        mbs.registerMBean(this, name);
+      }
     }
   }
 
@@ -544,8 +546,10 @@ public class Pool implements AutoCloseable, PoolMBean {
     String jmxName = poolTag.replace(":", "_");
     ObjectName name = new ObjectName("org.mariadb.jdbc.pool:type=" + jmxName);
 
-    if (mbs.isRegistered(name)) {
-      mbs.unregisterMBean(name);
+    synchronized (mbs) {
+      if (mbs.isRegistered(name)) {
+        mbs.unregisterMBean(name);
+      }
     }
   }
 

--- a/src/main/java/org/mariadb/jdbc/pool/Pools.java
+++ b/src/main/java/org/mariadb/jdbc/pool/Pools.java
@@ -107,7 +107,9 @@ public final class Pools {
       for (PoolHolder holder : poolMap.values()) {
         if (poolName.equals(holder.conf.poolName())) {
           try {
-            holder.getPool().close(); // Pool.close() calls Pools.remove(), which does the rest of the cleanup
+            holder
+                .getPool()
+                .close(); // Pool.close() calls Pools.remove(), which does the rest of the cleanup
           } catch (Exception exception) {
             // eat
           }

--- a/src/test/java/org/mariadb/jdbc/integration/PoolDataSourceTest.java
+++ b/src/test/java/org/mariadb/jdbc/integration/PoolDataSourceTest.java
@@ -791,17 +791,20 @@ public class PoolDataSourceTest extends Common {
     ExecutorService executor = Executors.newCachedThreadPool();
     try {
       // When many pools are created concurrently
-      List<Future<MariaDbPoolDataSource>> futures = IntStream
-          .rangeClosed(1, 5)
-          .mapToObj(hostIndex ->
-              executor.submit(() -> {
-                ready.countDown();
-                start.await();
-                MariaDbPoolDataSource ds = new MariaDbPoolDataSource();
-                ds.setUrl("jdbc:mariadb://myhost" + hostIndex + ":5500/db?someOption=val");
-                return ds;
-              }))
-          .collect(Collectors.toList());
+      List<Future<MariaDbPoolDataSource>> futures =
+          IntStream.rangeClosed(1, 5)
+              .mapToObj(
+                  hostIndex ->
+                      executor.submit(
+                          () -> {
+                            ready.countDown();
+                            start.await();
+                            MariaDbPoolDataSource ds = new MariaDbPoolDataSource();
+                            ds.setUrl(
+                                "jdbc:mariadb://myhost" + hostIndex + ":5500/db?someOption=val");
+                            return ds;
+                          }))
+              .collect(Collectors.toList());
 
       ready.await();
       start.countDown();


### PR DESCRIPTION
Creating many pools concurrently was slow because all threads are contending for `poolMap`, which is held while a `Pool` is being initialized (which can take a few seconds).

PoolHolder was introduced to lazily create a Pools. Creating a pool instance is synchronized on the PoolHolder and therefore only requests for the same pool instance (referenced by Configuration) will face contention.

Creating many Pool instances concurrently is probably not a usual use case, but does affect sharded environments where shards are behind different databases hosts. In my particular case, I need to run cross-shard queries to understand production data, which is a debugging and business insights task.